### PR TITLE
Pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/ci-client.yml
+++ b/.github/workflows/ci-client.yml
@@ -21,10 +21,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20.x"
           cache: "npm"

--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -21,10 +21,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20.x"
           cache: "npm"
@@ -40,7 +40,7 @@ jobs:
         run: npm run build -- --base=/narou/
 
       - name: deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: narou-react/build

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -13,10 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version: 1.18
 
@@ -30,7 +30,7 @@ jobs:
         GOARCH: "amd64"
 
     - name: Setup SSH
-      uses: kielabokkie/ssh-key-and-known-hosts-action@v1
+      uses: kielabokkie/ssh-key-and-known-hosts-action@242f53d26bbd43e843b08b0cbc8287ceb03fbe71 # v1.5.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
         ssh-host: ${{ secrets.SSH_HOST }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,10 +20,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version: 1.18
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to commit hashes instead of version tags to prevent supply chain attacks
- Replace version tags with full commit hashes and add version comments for readability
- Enables Dependabot to continue managing hash-pinned actions

## Changes
- `actions/checkout@v5` → `08c6903cd8...` (v5.0.0)
- `actions/setup-node@v5` → `a0853c2454...` (v5.0.0)  
- `actions/setup-go@v6` → `4469467582...` (v6.0.0)
- `peaceiris/actions-gh-pages@v4` → `4f9cc6602d...` (v4.0.0)
- `kielabokkie/ssh-key-and-known-hosts-action@v1` → `242f53d26b...` (v1.5.0)

## Test plan
- [ ] Verify CI workflow (ci-client.yml) runs successfully
- [ ] Verify Go test workflow (go.yml) runs successfully  
- [ ] Confirm no breaking changes in action behavior

🤖 Generated with [Claude Code](https://claude.ai/code)