### PR TITLE
chore: Claude Codeコマンドの追加とテストの修正

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,38 @@
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git checkout:*), Bash(git push:*), Bash(gh pr create:*), Bash(go fmt:*), Bash(go vet:*), Bash(go test:*), Bash(go build:*), Bash(npm run:*), Bash(npm test:*), Bash(git rev-parse:*)
+Description: create a pull request
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -10`
+- narou-react Directory へ移動: !`git rev-parse --show-toplevel` でプロジェクトルートパスを覚えておき、その下の `narou-react` にcdする
+
+## Your Task
+
+以下の作業を自動で実行してください(ユーザーの確認なしで進めてください):
+
+1. **プリチェック(現在のブランチで実行)**:
+   - Go: プロジェクトルートで `go fmt ./...` `go vet ./...` `go test ./...` `go build` を並列実行
+   - Frontend: narou-reactディレクトリに移動してから `npm run lint` `npm test:ci` `npm run build` を並列実行
+
+   ※エラーがあった場合のみ、ユーザーに報告して中断してください。
+
+2. **ブランチ作成とコミット**:
+   - 変更内容に基づいて適切なブランチ名を自動生成
+   - すべての変更をステージング(`git add .`)
+   - 変更内容と目的を分析して適切なコミットメッセージを自動生成
+   - コミット実行
+
+3. **PR作成**:
+   - ブランチをリモートにpush
+   - 変更内容を分析してPR説明を自動生成:
+     - 変更の概要(コミット内容から分析)
+     - テスト実行結果の確認
+   - mainブランチに対するPR作成
+   - PR URLを報告
+
+**重要**: 各ステップでエラーが発生した場合のみユーザーに報告し、成功時は次のステップに自動進行してください。

--- a/.claude/commands/merged.md
+++ b/.claude/commands/merged.md
@@ -1,0 +1,29 @@
+---
+allowed-tools: Bash(git checkout:*), Bash(git pull:*), Bash(git remote prune:*), Bash(git branch:*), Bash(git status:*), Bash(git log:*)
+description: Clean up after PR merge - switch to main branch and update
+---
+
+# PR Merge Cleanup
+
+Clean up after a PR has been merged. This command will:
+
+1. Switch to main branch
+2. Pull latest changes from origin
+3. Delete the merged branch locally
+4. Prune remote tracking branches
+
+## Context
+
+- Current branch: !`git branch --show-current`
+
+## Your task
+
+Perform post-merge cleanup for the branch: ${ARGUMENTS:-$(git branch --show-current)}
+
+Please execute the following steps immediately without confirmation:
+1. Save the current branch name
+2. Switch to main branch
+3. Pull latest changes from origin/main
+4. Delete the merged branch locally (use -D since GitHub auto-deletes merged branches)
+5. Prune remote tracking branches
+6. Show a summary of what was cleaned up

--- a/narou/IsNoticeList_test.go
+++ b/narou/IsNoticeList_test.go
@@ -23,7 +23,11 @@ func NewPageFromText(html string) (*scraper.Page, error) {
 		return nil, err
 	}
 
-	page := &scraper.Page{doc, testUrl, logger}
+	page := &scraper.Page{
+		Document: doc,
+		BaseUrl:  testUrl,
+		Logger:   logger,
+	}
 
 	return page, nil
 }

--- a/narou/TestDataProvider_test.go
+++ b/narou/TestDataProvider_test.go
@@ -87,11 +87,11 @@ func TestTestDataProvider_IsEpisodeAccessible(t *testing.T) {
 	provider := NewTestDataProvider(startTime)
 
 	tests := []struct {
-		name      string
-		ncode     string
-		episode   uint
-		wait      time.Duration
-		want      bool
+		name    string
+		ncode   string
+		episode uint
+		wait    time.Duration
+		want    bool
 	}{
 		{"regular episode immediately", "n0001aa", 1, 0, true},
 		{"n0002bb ep11 immediately", "n0002bb", 11, 0, false},


### PR DESCRIPTION
## Summary
- echonet-listプロジェクトから `create-pr` と `merged` コマンドを移植
- narou-watcherの構造に合わせて調整（`narou-react/` ディレクトリ、npmコマンド）
- Go vetエラー修正: `IsNoticeList_test.go` で `scraper.Page` 構造体リテラルをkeyed fieldsに変更

## Test plan
- [x] Go prechecks passed: `go fmt`, `go vet`, `go test`, `go build`
- [x] Frontend prechecks passed: `npm run lint`, `npm test:ci`, `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)