### PR TITLE
fix: BEWARE_TIME経過後に自動的に(注意)マークが消えるように修正

### DIFF
--- a/narou-react/src/components/NarouUpdateListItem.test.tsx
+++ b/narou-react/src/components/NarouUpdateListItem.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { format } from 'date-fns';
 import React from 'react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
@@ -52,23 +52,12 @@ describe('NarouUpdateListItem', () => {
 
     expect(elem.querySelector('.MuiListItemText-secondary')?.textContent).toEqual(withAlert);
 
-    // 時間経過後に再レンダリングすると (注意) マークが消える
-    // Change the time and create a new item with different timestamp to force recalculation
-    vi.setSystemTime(new Date(update_time + BEWARE_TIME + 1000)); // 3 minutes + 1 second after updated time
-    const newItem = {
-      ...item,
-      update_time: new Date(update_time + BEWARE_TIME + 1000 - BEWARE_TIME - 1000) // Same original time
-    }; 
-    const newRender = () =>
-      <NarouUpdateListItem data-testid="item"
-        item={newItem}
-        index={0}
-        isSelected
-        setSelectedIndex={() => {/* nothing */ }}
-        selectDefault={() => {/* nothing */ }}
-        onSecondaryAction={() => {/* nothing */ }}
-      />;
-    rendered.rerender(newRender());
+    // 時間経過後に自動的に (注意) マークが消える
+    // Advance time to trigger the timer
+    act(() => {
+      vi.advanceTimersByTime(BEWARE_TIME + 1000); // 3 minutes + 1 second
+    });
+
     const newElem = rendered.getByTestId('item');
     expect(newElem.querySelector('.MuiListItemText-secondary')?.textContent).toEqual(withoutAlert);
   });

--- a/narou-react/src/components/NarouUpdateListItem.tsx
+++ b/narou-react/src/components/NarouUpdateListItem.tsx
@@ -30,7 +30,7 @@ function NarouUpdateListItemRaw({ item, index, isSelected, setSelectedIndex, onS
   }, []);
 
   const ref = useRef<HTMLLIElement | null>(null);
-  const [, forceUpdate] = useState({});
+  const [currentTime, setCurrentTime] = useState(Date.now());
 
   useEffect(() => {
     if (isSelected) {
@@ -46,7 +46,7 @@ function NarouUpdateListItemRaw({ item, index, isSelected, setSelectedIndex, onS
     if (past < BEWARE_TIME) {
       const remainingTime = BEWARE_TIME - past;
       const timer = setTimeout(() => {
-        forceUpdate({});
+        setCurrentTime(Date.now());
       }, remainingTime);
 
       return () => {
@@ -55,11 +55,8 @@ function NarouUpdateListItemRaw({ item, index, isSelected, setSelectedIndex, onS
     }
   }, [item.update_time]);
 
-  // Use useMemo to calculate bewareTooNew consistently
-  const bewareTooNew = useMemo(() => {
-    const past = Date.now() - item.update_time.getTime();
-    return past < BEWARE_TIME;
-  }, [item.update_time]);
+  // Calculate bewareTooNew based on current time (recalculated on every render)
+  const bewareTooNew = currentTime - item.update_time.getTime() < BEWARE_TIME;
 
   const buttonProps = useMemo<ButtonTypeMap['props']>(() => {
     if (unread(item) > 0) {


### PR DESCRIPTION
## Summary

`bewareTooNew`の計算を`useMemo`から通常の変数計算に変更することで、BEWARE_TIME(3分)経過後に自動的に`(注意)`マークが消えるように修正しました。

## 変更内容

- **NarouUpdateListItem.tsx**:
  - `currentTime`状態を導入し、タイマーで`setCurrentTime()`を実行することで再レンダリングをトリガー
  - `bewareTooNew`の計算を`useMemo`から通常の変数計算に変更
  
- **NarouUpdateListItem.test.tsx**:
  - タイマーによる自動更新をテストするように修正
  - `act()`と`vi.advanceTimersByTime()`を使用

## 問題の原因

以前の実装では`bewareTooNew`を`useMemo`で計算していましたが、依存配列に現在時刻が含まれていなかったため、`forceUpdate({})`を実行しても`useMemo`が再計算されず、`(注意)`マークが消えませんでした。

## テスト結果

- ✅ Go: fmt, vet, test, build - すべて成功
- ✅ Frontend: lint, test:ci, build - すべて成功
- ✅ 全49テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)