### PR TITLE
fix: /check-novel-access/エンドポイントのキャッシュを無効化

### DIFF
--- a/main.go
+++ b/main.go
@@ -336,6 +336,12 @@ func (apiService *NarouApiService) HandlerFunc(handler NarouApiHandlerType) func
 	}
 }
 
+func SetNoCacheHeaders(w http.Header) {
+	w.Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	w.Set("Pragma", "no-cache")
+	w.Set("Expires", "0")
+}
+
 func ReturnJson(w http.Header, body interface{}) ([]byte, error) {
 	bin, err := json.Marshal(body)
 	if err != nil {
@@ -643,6 +649,7 @@ func checkNovelAccessHandler(baseUrl string, r18 bool) NarouApiHandlerType {
 			StatusCode: resp.StatusCode,
 		}
 
+		SetNoCacheHeaders(w)
 		return ReturnJson(w, result)
 	}
 }

--- a/testdata_handlers.go
+++ b/testdata_handlers.go
@@ -129,6 +129,7 @@ func testDataCheckNovelAccessHandler(provider *narou.TestDataProvider, ncode str
 			result.StatusCode = 404
 		}
 
+		SetNoCacheHeaders(w)
 		return ReturnJson(w, result)
 	}
 }


### PR DESCRIPTION
## Summary

小説エピソードのアクセス可否チェックAPI (`/check-novel-access/`) のレスポンスがブラウザやプロキシにキャッシュされないように、適切なキャッシュ制御ヘッダーを追加しました。

## Changes

- **SetNoCacheHeaders関数を追加**: キャッシュ無効化ヘッダーの設定を共通化
  - `Cache-Control: no-store, no-cache, must-revalidate, max-age=0`
  - `Pragma: no-cache`
  - `Expires: 0`
- **checkNovelAccessHandler**: 本番用ハンドラーにキャッシュ制御を適用
- **testDataCheckNovelAccessHandler**: テストデータモード用ハンドラーにも同様に適用

## Why

`/check-novel-access/` エンドポイントは、新着更新リストには表示されているが、サーバーのレプリケーションラグなどによってまだ小説ページが見えていないときに、見えるようになるまでポーリングするためのAPIです。

このレスポンスがキャッシュされると、実際にはページが見えるようになっているのに古いキャッシュにより「まだ見えない」と判定され続け、ユーザーが小説を読めない問題が発生します。そのため、このエンドポイントのみキャッシュを無効化する必要がありました。

## Test plan

- [x] Go: `go fmt`, `go vet`, `go test`, `go build` - すべて成功
- [x] Frontend: `npm run lint`, `npm run test:ci`, `npm run build` - すべて成功
- [x] 51個のテストが成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)