### PR TITLE
fix: iPhone Safariでダイアログが即座に閉じる問題を修正

### DIFF
--- a/narou-react/src/components/WaitingForNovelDialog.tsx
+++ b/narou-react/src/components/WaitingForNovelDialog.tsx
@@ -155,7 +155,15 @@ function WaitingForNovelDialogRaw({ api, item, onClose }: {
   const isMaxRetriesReached = retryCount >= MAX_RETRY_COUNT;
 
   return (
-    <Dialog open={!!item} onClose={handleCancel} disableEscapeKeyDown>
+    <Dialog
+      open={!!item}
+      onClose={(event, reason) => {
+        if (reason !== 'backdropClick') {
+          handleCancel();
+        }
+      }}
+      disableEscapeKeyDown
+    >
       <DialogTitle>小説の公開を待っています...</DialogTitle>
       <DialogContent>
         <DialogContentText>


### PR DESCRIPTION
## Summary

- iPhone SafariでWaitingForNovelDialogを開いた際、ダイアログが即座に閉じてしまう問題への対処

## Changes

- `WaitingForNovelDialog.tsx`: `Dialog`の`onClose`ハンドラで`reason`パラメータをチェック
- バックドロップクリック(`backdropClick`)の場合は閉じる処理をスキップ
- 明示的なキャンセルボタンクリック等のみを受け付けるように変更

## Root Cause (仮説)

iPhone Safariのタッチイベント処理の特性により、リストアイテムをタップした際のイベントが、レンダリングされたダイアログのバックドロップまでバブリング。Material-UIがこれをバックドロップクリックと判定して`onClose`を呼び出し、ダイアログが即座に閉じている可能性がある。

**注: これは仮説による修正です。**

## Verification Plan

- マージ後、本番環境でiPhone Safariを使用して実機確認
- 更新直後の小説を開く操作でダイアログが正しく表示されることを確認
- 検証結果は小説の更新タイミングに依存するため、即座には確認できない見込み

## Side Effects

バックドロップクリックによるダイアログの閉じる動作を無効化しますが、以下の理由により副作用は最小限と判断:
- キャンセルボタンによる明示的な閉じる操作は引き続き機能
- ESCキーはすでに`disableEscapeKeyDown`で無効化されている
- ポーリング中のダイアログは自動で開くことが目的であり、バックドロップクリックで閉じる必要性は低い

## Test Results

### Go Backend
- ✅ `go fmt ./...`: OK
- ✅ `go vet ./...`: OK
- ✅ `go test ./...`: OK
- ✅ `go build`: OK

### Frontend
- ✅ `npm run lint`: OK
- ✅ `npm run test:ci`: 51 tests passed
- ✅ `npm run build`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)