### PR TITLE
ci: update Node.js version from 20.x to 22.x

### DIFF
--- a/.github/workflows/ci-client.yml
+++ b/.github/workflows/ci-client.yml
@@ -34,7 +34,7 @@ jobs:
       - name: setup-node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
           cache-dependency-path: "narou-react/package-lock.json"
 

--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -26,7 +26,7 @@ jobs:
       - name: setup-node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
           cache-dependency-path: "narou-react/package-lock.json"
 


### PR DESCRIPTION
## Summary

- Update GitHub Actions workflows to use Node.js 22.x instead of 20.x
- Affects `ci-client.yml` and `deploy-client.yml`

## Changes

- `.github/workflows/ci-client.yml`: Update `node-version` from `20.x` to `22.x`
- `.github/workflows/deploy-client.yml`: Update `node-version` from `20.x` to `22.x`

## Benefits

- Ensures CI environment uses the latest Node.js LTS version
- Improves build performance and compatibility with modern dependencies

## Test Plan

- [x] Go precheck passed: `go fmt`, `go vet`, `go test`, `go build`
- [x] Frontend precheck passed: `npm run lint`, `npm run test:ci`, `npm run build`
- [ ] Verify CI runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)