### PR TITLE
feat: handle iPhone Safari popup blocking in WaitingForNovelDialog

### DIFF
--- a/narou-react/src/components/WaitingForNovelDialog.tsx
+++ b/narou-react/src/components/WaitingForNovelDialog.tsx
@@ -11,6 +11,7 @@ import {
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { IsNoticeListItem, nextLink } from '../narouApi/IsNoticeListItem';
 import { NarouApi } from '../narouApi/NarouApi';
+import { isIPhoneSafari } from '../utils/browser';
 import { CountdownTimer } from './CountdownTimer';
 
 const POLLING_INTERVAL = 30 * 1000; // 30 seconds
@@ -31,6 +32,7 @@ function WaitingForNovelDialogRaw({ api, item, onClose, onAccessible }: {
   const [retryCount, setRetryCount] = useState(0);
   const [isChecking, setIsChecking] = useState(false);
   const [nextCheckTime, setNextCheckTime] = useState<Date | null>(null);
+  const [isAccessible, setIsAccessible] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const extractNcodeAndEpisode = useCallback((item: IsNoticeListItem) => {
@@ -71,14 +73,25 @@ function WaitingForNovelDialogRaw({ api, item, onClose, onAccessible }: {
       const accessible = await checkNovelAccess(item);
 
       if (accessible) {
-        // Novel is now accessible, stop polling and open it
+        // Novel is now accessible, stop polling
         if (intervalRef.current) {
           clearInterval(intervalRef.current);
           intervalRef.current = null;
         }
         setNextCheckTime(null); // カウントダウン停止
         onAccessible?.(item);
-        openNovel(item);
+
+        // Handle differently for iPhone Safari vs others
+        if (isIPhoneSafari()) {
+          // iPhone Safari: Show "accessible" state and vibrate
+          setIsAccessible(true);
+          if ('vibrate' in navigator) {
+            navigator.vibrate([200, 100, 200]);
+          }
+        } else {
+          // Other browsers: Auto-open as before
+          openNovel(item);
+        }
         return;
       }
 
@@ -112,6 +125,7 @@ function WaitingForNovelDialogRaw({ api, item, onClose, onAccessible }: {
     if (item) {
       setRetryCount(0);
       setIsChecking(false);
+      setIsAccessible(false);
       setNextCheckTime(new Date(Date.now() + POLLING_INTERVAL)); // 初回の次回チェック時刻
       startPolling(item);
     }
@@ -147,7 +161,16 @@ function WaitingForNovelDialogRaw({ api, item, onClose, onAccessible }: {
       const accessible = await checkNovelAccess(item);
       if (accessible) {
         onAccessible?.(item);
-        openNovel(item);
+
+        // Handle differently for iPhone Safari vs others
+        if (isIPhoneSafari()) {
+          setIsAccessible(true);
+          if ('vibrate' in navigator) {
+            navigator.vibrate([200, 100, 200]);
+          }
+        } else {
+          openNovel(item);
+        }
       } else {
         // 次回チェック時刻をリセット
         setNextCheckTime(new Date(Date.now() + POLLING_INTERVAL));
@@ -167,60 +190,100 @@ function WaitingForNovelDialogRaw({ api, item, onClose, onAccessible }: {
       }}
       disableEscapeKeyDown
     >
-      <DialogTitle>小説の公開を待っています...</DialogTitle>
+      <DialogTitle>
+        {isAccessible ? '✅ 小説が公開されました！' : '小説の公開を待っています...'}
+      </DialogTitle>
       <DialogContent>
-        <DialogContentText>
-          「{item?.title}」の次の話がまだ公開されていません。
-        </DialogContentText>
-        <DialogContentText>
-          自動的に公開をチェックし、公開され次第開きます。
-        </DialogContentText>
-        <Typography variant="body2" color="text.secondary" sx={{ mt: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
-          {isChecking && <CircularProgress size={16} />}
-          {isChecking
-            ? '確認中...'
-            : isMaxRetriesReached
-              ? '最大試行回数に達しました'
-              : (
-                <CountdownTimer
-                  targetTime={nextCheckTime}
-                  intervalMs={POLLING_INTERVAL}
-                />
-              )
-          }
-        </Typography>
-        {retryCount > 0 && (
-          <Typography variant="body2" color="text.secondary">
-            確認回数: {retryCount}/{MAX_RETRY_COUNT}
-          </Typography>
+        {isAccessible ? (
+          <>
+            <DialogContentText>
+              「{item?.title}」が公開されました！
+            </DialogContentText>
+            <DialogContentText>
+              もう一度小説をタップして開いてください。
+            </DialogContentText>
+          </>
+        ) : (
+          <>
+            <DialogContentText>
+              「{item?.title}」の次の話がまだ公開されていません。
+            </DialogContentText>
+            <DialogContentText>
+              自動的に公開をチェックし、公開され次第開きます。
+            </DialogContentText>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
+              {isChecking && <CircularProgress size={16} />}
+              {isChecking
+                ? '確認中...'
+                : isMaxRetriesReached
+                  ? '最大試行回数に達しました'
+                  : (
+                    <CountdownTimer
+                      targetTime={nextCheckTime}
+                      intervalMs={POLLING_INTERVAL}
+                    />
+                  )
+              }
+            </Typography>
+            {retryCount > 0 && (
+              <Typography variant="body2" color="text.secondary">
+                確認回数: {retryCount}/{MAX_RETRY_COUNT}
+              </Typography>
+            )}
+          </>
         )}
       </DialogContent>
       <DialogActions>
-        <Button 
-          onClick={handleManualRetry} 
-          variant="outlined" 
-          size="small"
-          disabled={isChecking}
-          data-testid="manual-retry-button"
-        >
-          今すぐ確認
-        </Button>
-        <Button 
-          onClick={handleOpenAnyway} 
-          variant="outlined" 
-          size="small"
-          data-testid="open-anyway-button"
-        >
-          そのまま開く
-        </Button>
-        <Button 
-          onClick={handleCancel} 
-          variant="contained" 
-          size="small"
-          data-testid="cancel-button"
-        >
-          キャンセル
-        </Button>
+        {isAccessible ? (
+          <>
+            <Button
+              onClick={handleCancel}
+              variant="outlined"
+              size="medium"
+              data-testid="close-button"
+            >
+              閉じる
+            </Button>
+            <Button
+              onClick={handleOpenAnyway}
+              variant="contained"
+              size="medium"
+              color="primary"
+              data-testid="open-novel-button"
+              autoFocus
+            >
+              小説を開く
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              onClick={handleManualRetry}
+              variant="outlined"
+              size="small"
+              disabled={isChecking}
+              data-testid="manual-retry-button"
+            >
+              今すぐ確認
+            </Button>
+            <Button
+              onClick={handleOpenAnyway}
+              variant="outlined"
+              size="small"
+              data-testid="open-anyway-button"
+            >
+              そのまま開く
+            </Button>
+            <Button
+              onClick={handleCancel}
+              variant="contained"
+              size="small"
+              data-testid="cancel-button"
+            >
+              キャンセル
+            </Button>
+          </>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/narou-react/src/utils/browser.test.ts
+++ b/narou-react/src/utils/browser.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isIPhoneSafari } from './browser';
+
+describe('isIPhoneSafari', () => {
+  let originalUserAgent: string;
+
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+  });
+
+  afterEach(() => {
+    // Restore original userAgent
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+  });
+
+  const setUserAgent = (ua: string) => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: ua,
+      configurable: true,
+    });
+  };
+
+  it('should return true for iPhone Safari', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1');
+    expect(isIPhoneSafari()).toBe(true);
+  });
+
+  it('should return false for iPhone Chrome', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/119.0.6045.109 Mobile/15E148 Safari/604.1');
+    expect(isIPhoneSafari()).toBe(false);
+  });
+
+  it('should return false for iPhone Firefox', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/119.0 Mobile/15E148 Safari/605.1.15');
+    expect(isIPhoneSafari()).toBe(false);
+  });
+
+  it('should return false for iPad Safari', () => {
+    setUserAgent('Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1');
+    expect(isIPhoneSafari()).toBe(false);
+  });
+
+  it('should return false for Mac Safari', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15');
+    expect(isIPhoneSafari()).toBe(false);
+  });
+
+  it('should return false for Android Chrome', () => {
+    setUserAgent('Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.193 Mobile Safari/537.36');
+    expect(isIPhoneSafari()).toBe(false);
+  });
+
+  it('should return false for Windows Chrome', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36');
+    expect(isIPhoneSafari()).toBe(false);
+  });
+});

--- a/narou-react/src/utils/browser.ts
+++ b/narou-react/src/utils/browser.ts
@@ -1,0 +1,11 @@
+/**
+ * Check if the current browser is Safari on iPhone
+ * @returns true if the browser is Safari on iPhone, false otherwise
+ */
+export function isIPhoneSafari(): boolean {
+  const ua = navigator.userAgent;
+  const isIPhone = ua.includes('iPhone');
+  // Safari has "Safari" in UA, but Chrome/CriOS/FxiOS do not
+  const isSafari = ua.includes('Safari') && !ua.includes('Chrome') && !ua.includes('CriOS') && !ua.includes('FxiOS');
+  return isIPhone && isSafari;
+}


### PR DESCRIPTION
## Summary

iPhone SafariではユーザージェスチャーからでないとwindowをOpenできないため、小説が公開されたことを確認したら自動でOpenする機能が動作しませんでした。この変更により、iPhone Safariでは公開成功ダイアログを表示し、ユーザーが手動で開くボタンをクリックする仕様に変更しました。

## Changes

### 新規ファイル
- **`src/utils/browser.ts`**: iPhone Safari判定関数 `isIPhoneSafari()` を実装
- **`src/utils/browser.test.ts`**: 包括的なブラウザ判定テスト（7ケース）

### 修正ファイル
- **`src/components/WaitingForNovelDialog.tsx`**:
  - 小説が公開されたときの動作をブラウザで分岐
  - iPhone Safari: 成功ダイアログ表示 + 振動通知 + 手動オープンボタン
  - その他のブラウザ: 従来通り自動オープン

## Behavior

### iPhone Safari
1. 小説が公開されたら成功ダイアログを表示
2. 振動で通知（`navigator.vibrate([200, 100, 200])`）
3. ユーザーが「小説を開く」ボタンをクリック→新しいタブで開く

### その他のブラウザ（PC/Android/Chrome等）
- 従来通り自動で新しいタブで開く

## Test Results

✅ すべてのテストが成功
- **Go**: `go fmt`, `go vet`, `go test`, `go build` すべてパス
- **Frontend**: `npm run lint`, `npm test:ci`, `npm run build` すべてパス
  - 新規追加: `browser.test.ts` 7テスト（iPhone Safari, iPhone Chrome, iPhone Firefox, iPad Safari, Mac Safari, Android Chrome, Windows Chrome）
  - 既存テスト: 65テストすべてパス

## Technical Notes

- User-Agent文字列による判定（`String.includes()` を使用）
- 振動APIは `'vibrate' in navigator` でチェック（型安全）
- `isAccessible` stateで公開済み状態を管理
- 自動フォーカスで「小説を開く」ボタンをハイライト

🤖 Generated with [Claude Code](https://claude.com/claude-code)