### PR TITLE
chore(narou-react): MUI v9 アップグレード準備

### DIFF
--- a/narou-react/src/components/NarouLoginForm.tsx
+++ b/narou-react/src/components/NarouLoginForm.tsx
@@ -47,7 +47,7 @@ export function NarouLoginForm(props: { api: NarouApi; onLogin: () => void; }) {
         <CardHeader title="小説家になろうのログイン情報" data-testid="login-page">
         </CardHeader>
         <CardContent>
-          <Box display="flex" flexDirection="column" justifyContent="center">
+          <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
             <TextField id="id" name="id" label="ID or email" autoFocus
               value={userId} onChange={e => { setUserId(e.target.value); }}
               onKeyDown={e => {

--- a/narou-react/src/components/NarouUpdateListItem.tsx
+++ b/narou-react/src/components/NarouUpdateListItem.tsx
@@ -1,4 +1,5 @@
-import { Book, Info } from '@mui/icons-material';
+import Book from '@mui/icons-material/Book';
+import Info from '@mui/icons-material/Info';
 import {
   Avatar, Badge, BadgeTypeMap, ButtonTypeMap, IconButton, ListItem,
   ListItemAvatar,

--- a/narou-react/src/components/NarouUpdates.tsx
+++ b/narou-react/src/components/NarouUpdates.tsx
@@ -169,7 +169,7 @@ function NarouUpdateScreen({ server, onUnauthorized }: { server: NarouApi, onUna
         <Box>
           <BookmarkSelector bookmarks={bookmarks} bookmark={bookmark} onChangeBookmark={setBookmark} />
         </Box>
-        <Box m={2}>未読: {numNewItems ?? ''}</Box>
+        <Box sx={{ m: 2 }}>未読: {numNewItems ?? ''}</Box>
         <Button
           variant="contained"
           disabled={selectedIndex === 0}
@@ -178,8 +178,8 @@ function NarouUpdateScreen({ server, onUnauthorized }: { server: NarouApi, onUna
           onClick={selectDefault}>ESC</Button>
       </Toolbar>
     </AppBar>
-    <Box display="flex" alignItems="center" flexDirection="column" bgcolor="background.paper">
-      <Box maxWidth={600}>
+    <Box sx={{ display: 'flex', alignItems: 'center', flexDirection: 'column', bgcolor: 'background.paper' }}>
+      <Box sx={{ maxWidth: 600 }}>
         <NarouUpdateList items={items}
           selectedIndex={selectedIndex} setSelectedIndex={setSelectedIndex}
           selectCommand={selectCommand}
@@ -187,7 +187,7 @@ function NarouUpdateScreen({ server, onUnauthorized }: { server: NarouApi, onUna
           onWaitingAction={setWaiting}
         />
       </Box>
-      <Box position="fixed" right="20px" bottom="20px">
+      <Box sx={{ position: 'fixed', right: '20px', bottom: '20px' }}>
         <Fab
           variant="extended"
           size="small"

--- a/narou-react/src/components/OpenConfirmDialog.tsx
+++ b/narou-react/src/components/OpenConfirmDialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
   Link, Typography
 } from '@mui/material';
-import { Bookmark } from '@mui/icons-material';
+import Bookmark from '@mui/icons-material/Bookmark';
 import React, { useMemo } from 'react';
 import { IsNoticeListItem, nextLink } from '../narouApi/IsNoticeListItem';
 import { NarouApi } from '../narouApi/NarouApi';


### PR DESCRIPTION
## Summary

- 現行 MUI v7 のまま、v9 アップグレード時に問題になる箇所を先行で是正。PR #2087 (MUI v9 自動更新) は breaking change で落ちているため本体には触らず、現在のバージョンでできる準備のみを行う。
- `Box` の shorthand style props (`m`, `display`, `flexDirection`, `bgcolor`, `maxWidth`, `position`, 等) を `sx` prop に統一。v9 ではこれらが DOM に転送されるようになり、未修正だと React の unknown DOM attribute 警告/エラーが発生する。
- `@mui/icons-material` を named import から path import に変更（MUI [#46324](https://github.com/mui/material-ui/issues/46324)）。named import はビルド/テスト時にアイコン全件を引き込み、CI 時間が大幅に悪化する。

### 変更ファイル

- `NarouUpdates.tsx` (4 箇所), `NarouLoginForm.tsx` (1 箇所): Box → sx
- `NarouUpdateListItem.tsx`, `OpenConfirmDialog.tsx`: icons-material を path import 化 (Book / Info / Bookmark)

## Test plan

- [x] `go fmt ./...` / `go vet ./...` / `go test ./...` / `go build` — all green
- [x] `npm run lint` — clean
- [x] `npm run test:ci` — 10 files / 77 tests passed
- [x] `npm run build` — success
- [ ] 手動動作確認: ログインフォーム / AppBar の「未読」表示 / リストの Book・Info アイコン / 詳細ダイアログの Bookmark アイコン

🤖 Generated with [Claude Code](https://claude.com/claude-code)