### PR TITLE
refactor(WaitingForNovelDialog): reset derived state during render

### DIFF
--- a/narou-react/src/components/WaitingForNovelDialog.tsx
+++ b/narou-react/src/components/WaitingForNovelDialog.tsx
@@ -113,12 +113,17 @@ function WaitingForNovelDialogRaw({ api, item, onClose, onAccessible }: {
     }, POLLING_INTERVAL);
   }, [checkNovelAccess, onAccessible, openNovel]);
 
+  const [prevItem, setPrevItem] = useState(item);
+  if (prevItem !== item) {
+    setPrevItem(item);
+    setRetryCount(0);
+    setIsChecking(false);
+    setIsAccessible(false);
+    setNextCheckTime(null);
+  }
+
   useEffect(() => {
     if (item) {
-      setRetryCount(0);
-      setIsChecking(false);
-      setIsAccessible(false);
-      setNextCheckTime(new Date(Date.now() + POLLING_INTERVAL)); // 初回の次回チェック時刻
       startPolling(item);
     }
 
@@ -127,7 +132,6 @@ function WaitingForNovelDialogRaw({ api, item, onClose, onAccessible }: {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
       }
-      setNextCheckTime(null);
     };
   }, [item, startPolling]);
 


### PR DESCRIPTION
## Summary
- `item` prop 変化時の state リセットを `useEffect` から「adjust state during render」パターンに移行
- `useEffect` は副作用(`startPolling` とインターバルの cleanup)だけを担う形に
- 初期 `nextCheckTime` 設定を廃止(初回 poll が即 `setIsChecking(true)` を同期発火するため UI は「確認中...」表示になり、直前のカウントダウンは元々視認されない)

## なぜ
Dependabot PR #2102 (`eslint-plugin-react-hooks` 7.0.1 → 7.1.0)で以下の 2 ルールが強化/追加され、既存コードが該当:

1. `react-hooks/set-state-in-effect`: 元コードの useEffect は先頭で 4 連続の sync setState を呼んでいた(`setRetryCount(0)` ほか)
2. `react-hooks/purity`: `Date.now()` は render 中呼び出し不可

今回の修正は依存バージョンに関係なく有効な改善なので main に直接入れ、これをマージしてから #2102 を rebase すれば CI が通る想定。

## Test plan
- [x] `npm run lint` (7.0.1 現行) クリーン
- [x] `npm run build` (7.0.1) クリーン
- [x] `npm test -- --run` (7.0.1) 77 passed
- [x] `npm install --save-dev --no-save eslint-plugin-react-hooks@7.1.0` で一時導入し、lint/build/test すべてクリーンを確認
- [x] `npm ci` で package/lock 復元

🤖 Generated with [Claude Code](https://claude.com/claude-code)