### PR TITLE
chore: add words to cSpell dictionary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,17 @@
 {
   "cSpell.words": [
+    "cooldown",
+    "gomod",
     "goquery",
     "isnoticelist",
     "luxon",
+    "narou",
     "ncode",
     "peaceiris",
     "Puerkito",
     "testdata",
+    "vite",
+    "vitejs",
     "vitest"
   ]
 }


### PR DESCRIPTION
## Summary

- `cooldown`, `gomod`, `narou`, `vite`, `vitejs` をcSpell辞書に追加し、VS Codeのスペルチェック誤警告を抑制

## Test plan

- [x] `go fmt ./...` / `go vet ./...` / `go test ./...` / `go build` — 全パス
- [x] `npm run lint` — 全パス
- [x] `npm run test:ci` (77 tests) — 全パス
- [x] `npm run build` — 全パス