### PR TITLE
ci: CIのGoツールチェーンを1.26に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25
+          go-version: "1.26"
 
       - name: Build
         run: go build -v ./...
@@ -415,7 +415,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25
+          go-version: "1.26"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: 1.25
+        go-version: "1.26"
 
     - name: Test
       run: go test -v ./...


### PR DESCRIPTION
## 概要

CI / デプロイの `setup-go` は `go-version: 1.25` のままだったが、ローカルの Go ツールチェーンは 1.26.3 に更新済み。CIの3か所を `"1.26"` に揃える。

## 変更内容

`go-version: 1.25` → `go-version: "1.26"`(setup-go が最新 1.26.x を取得):
- `.github/workflows/ci.yml` — `go-test` ジョブ
- `.github/workflows/ci.yml` — `go-vuln` ジョブ
- `.github/workflows/deploy-server.yml` — `build` ジョブ

`.nvmrc` の `22`(メジャーのみ・パッチ自動追従)と同じ方針で、マイナーまで指定しパッチは自動追従。YAML の数値解釈の罠を避けるためクォート。

## 効果

`go-vuln` ジョブが最新 1.26.x(≥1.26.3)でスキャンするようになり、`govulncheck` が Go 1.26.0 に対して報告していた**標準ライブラリ由来の到達可能な脆弱性10件**(GO-2026-4599〜4976、いずれも 1.26.1〜1.26.3 で修正済み)がCI上でも解消する。

`go.mod` の `go 1.25.0` は**変更しない** — これは言語/最小バージョンの記録であり、ビルドに使うツールチェーン(setup-go の `go-version`)とは独立。Go 1.26 ツールチェーンは `go 1.25.0` モジュールを問題なくビルドする。

## テスト

ローカル(Go 1.26.3)で全プリチェック合格:
- Go: `gofmt`(クリーン)、`go vet ./...`、`go test ./...`、`go build ./...` すべてパス
- フロントエンド: `npm run lint`、`npm run test:ci`(77テスト合格)、`npm run build` すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)