### PR TITLE
ci: narou-react のCIジョブを分割して並列化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs when a PR is pushed repeatedly.
+# The snapshot auto-commit pushes via GITHUB_TOKEN, which does not trigger a new
+# workflow run, so this never cancels the run that produced the snapshot commit.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read
@@ -63,11 +70,46 @@ jobs:
       - name: Test
         run: go test -v ./...
 
-  react-test:
-    name: React Build Test
+  # Playwright is not needed here, so these run in parallel with react-visual.
+  react-quality:
+    name: React Quality
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.react == 'true'
+    # Snapshot update PRs only touch PNGs - skip the full suite (pre-validated).
+    if: needs.changes.outputs.react == 'true' && !startsWith(github.head_ref, 'update-visual-snapshots')
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: narou-react
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: setup-node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: narou-react/.nvmrc
+          cache: "npm"
+          cache-dependency-path: "narou-react/package-lock.json"
+
+      - name: Install
+        run: npm ci
+
+      - name: Unit Tests
+        run: npm run test:ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+  react-visual:
+    name: React Visual Regression
+    runs-on: ubuntu-latest
+    needs: changes
+    # Snapshot update PRs only touch PNGs - skip the full suite (pre-validated).
+    if: needs.changes.outputs.react == 'true' && !startsWith(github.head_ref, 'update-visual-snapshots')
     permissions:
       contents: write
       pull-requests: write
@@ -81,21 +123,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Quick validation for snapshot update PRs - skip full test suite
-      - name: Check if snapshot update PR
-        id: check-snapshot-pr
-        run: |
-          if [[ "${{ github.head_ref }}" == update-visual-snapshots* ]]; then
-            echo "is_snapshot_pr=true" >> $GITHUB_OUTPUT
-            echo "✅ Snapshot update PR detected"
-            echo "Skipping full test suite - snapshots are pre-validated"
-            echo "Full CI will run on next component change PR"
-          else
-            echo "is_snapshot_pr=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: setup-node
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: narou-react/.nvmrc
@@ -103,16 +131,13 @@ jobs:
           cache-dependency-path: "narou-react/package-lock.json"
 
       - name: Install
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true'
         run: npm ci
 
       - name: Get Playwright version
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true'
         id: playwright-version
         run: echo "version=$(npm list playwright --json | jq -r '.dependencies.playwright.version')" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
@@ -120,13 +145,13 @@ jobs:
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Browsers
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
         env:
           DEBIAN_FRONTEND: noninteractive
 
       - name: Install Playwright dependencies only
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: |
           sudo apt-get update -qq
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
@@ -136,12 +161,7 @@ jobs:
             libxshmfence1 libglib2.0-0 \
             fonts-liberation fonts-noto-color-emoji fonts-unifont
 
-      - name: Unit Tests
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true'
-        run: npm run test:ci
-
       - name: Check for existing snapshots
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true'
         id: check-snapshots
         run: |
           if [ -d "src/components/__screenshots__" ] && [ "$(find src/components/__screenshots__ -name '*-linux.png' | wc -l)" -gt 0 ]; then
@@ -151,13 +171,13 @@ jobs:
           fi
 
       - name: Visual Regression Tests (PR - Report Only)
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.check-snapshots.outputs.exists == 'true' && github.event_name == 'pull_request'
+        if: steps.check-snapshots.outputs.exists == 'true' && github.event_name == 'pull_request'
         continue-on-error: true
         id: visual-test-pr
         run: npm run test:visual:ci
 
       - name: Upload Visual Test Diff (PR)
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.visual-test-pr.outcome == 'failure'
+        if: steps.visual-test-pr.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: visual-test-diff
@@ -167,11 +187,11 @@ jobs:
           retention-days: 7
 
       - name: Update Visual Snapshots (PR with changes)
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.visual-test-pr.outcome == 'failure' && github.event_name == 'pull_request'
+        if: steps.visual-test-pr.outcome == 'failure' && github.event_name == 'pull_request'
         run: npm run test:visual:update
 
       - name: Commit Updated Snapshots (PR with changes)
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.visual-test-pr.outcome == 'failure' && github.event_name == 'pull_request'
+        if: steps.visual-test-pr.outcome == 'failure' && github.event_name == 'pull_request'
         working-directory: .
         run: |
           git config user.name "github-actions[bot]"
@@ -183,7 +203,7 @@ jobs:
           fi
 
       - name: Comment on PR about visual changes
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.visual-test-pr.outcome == 'failure'
+        if: steps.visual-test-pr.outcome == 'failure'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -195,11 +215,11 @@ jobs:
             })
 
       - name: Generate Initial Snapshots (First PR)
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.check-snapshots.outputs.exists == 'false'
+        if: steps.check-snapshots.outputs.exists == 'false'
         run: npm run test:visual:update
 
       - name: Commit Generated Snapshots (First PR)
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.check-snapshots.outputs.exists == 'false' && github.event_name == 'pull_request'
+        if: steps.check-snapshots.outputs.exists == 'false' && github.event_name == 'pull_request'
         working-directory: .
         run: |
           git config user.name "github-actions[bot]"
@@ -210,17 +230,9 @@ jobs:
             git push
           fi
 
-      - name: Build
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true'
-        run: npm run build
-
-      - name: Lint
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true'
-        run: npm run lint
-
       # Create Check Run on snapshot commit so CI Summary passes for the new commit
       - name: Get new commit SHA after snapshot update
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.visual-test-pr.outcome == 'failure'
+        if: steps.visual-test-pr.outcome == 'failure'
         id: get-new-sha
         working-directory: .
         run: |
@@ -228,7 +240,7 @@ jobs:
           echo "sha=$(git rev-parse origin/${{ github.head_ref }})" >> $GITHUB_OUTPUT
 
       - name: Create Check Run for snapshot commit
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.visual-test-pr.outcome == 'failure'
+        if: steps.visual-test-pr.outcome == 'failure'
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -238,10 +250,10 @@ jobs:
           conclusion: success
           details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           output: |
-            {"summary": "Build and lint passed. Visual snapshots were auto-updated."}
+            {"summary": "Visual snapshots were auto-updated."}
 
       - name: Get new commit SHA after initial snapshot
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.check-snapshots.outputs.exists == 'false'
+        if: steps.check-snapshots.outputs.exists == 'false'
         id: get-initial-sha
         working-directory: .
         run: |
@@ -249,7 +261,7 @@ jobs:
           echo "sha=$(git rev-parse origin/${{ github.head_ref }})" >> $GITHUB_OUTPUT
 
       - name: Create Check Run for initial snapshot commit
-        if: steps.check-snapshot-pr.outputs.is_snapshot_pr != 'true' && steps.check-snapshots.outputs.exists == 'false'
+        if: steps.check-snapshots.outputs.exists == 'false'
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -259,12 +271,12 @@ jobs:
           conclusion: success
           details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           output: |
-            {"summary": "Build and lint passed. Initial visual snapshots were generated."}
+            {"summary": "Initial visual snapshots were generated."}
 
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [changes, go-test, react-test]
+    needs: [changes, go-test, react-quality, react-visual]
     if: always()
     steps:
       - name: Check CI Results


### PR DESCRIPTION
## Context

PR時のCI(`ci.yml`)の web部分(`narou-react/`)は `React Build Test` という単一ジョブで全処理を直列実行しており、CIのボトルネックになっている。

GitHub Actions ログの実測(直近の典型run、約73秒):

| ステップ | 時間 | Playwright |
|---|---|---|
| setup + checkout + setup-node | ~6s | - |
| Install (npm ci) | 14s | - |
| Cache Playwright browsers | 6s | ✅ |
| Install Playwright dependencies (apt-get) | 16s | ✅ |
| Unit Tests | 7s | ❌ |
| Visual Regression Tests | 10s | ✅ |
| Build | ~1s | ❌ |
| Lint | 9s | ❌ |

`Unit Tests` / `Build` / `Lint` は Playwright 不要なのに、同一ジョブの手順順序のせいで Playwright セットアップ(~22s)の後ろで待たされていた。

## 変更内容

- `React Build Test` を **`react-quality`**(Unit/Build/Lint・Playwright不要・read-only)と **`react-visual`**(Visual Regression + スナップショット自動更新)の2ジョブに分割し、`Detect Changes` 後に並列実行
- 連続push時に古い実行をキャンセルする `concurrency` を追加
- スナップショット更新PRのスキップ判定を各ステップの `is_snapshot_pr` 条件 → ジョブレベルの `if` に集約(`Check if snapshot update PR` ステップを撤去)
- `ci-summary` の `needs` を新ジョブ名に更新

mainブランチ保護の必須チェックは `CI Summary` のみのため、ジョブ分割・改名は安全。

## 期待効果

| | 変更前 | 変更後 |
|---|---|---|
| React部分(律速) | ~73s | ~56s(`react-visual`が律速、`react-quality`は~41s) |
| CI全体 | ~95〜130s | ~75〜95s |

## 確認ポイント

- `React Quality` と `React Visual Regression` が並列実行されること
- `CI Summary` が引き続き通過すること(branch保護)

🤖 Generated with [Claude Code](https://claude.com/claude-code)