### PR TITLE
ci: .nvmrc 変更を setup-node の npm cache key に反映

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
         with:
           node-version-file: narou-react/.nvmrc
           cache: "npm"
-          cache-dependency-path: "narou-react/package-lock.json"
+          cache-dependency-path: |
+            narou-react/package-lock.json
+            narou-react/.nvmrc
 
       - name: Install
         run: npm ci
@@ -128,7 +130,9 @@ jobs:
         with:
           node-version-file: narou-react/.nvmrc
           cache: "npm"
-          cache-dependency-path: "narou-react/package-lock.json"
+          cache-dependency-path: |
+            narou-react/package-lock.json
+            narou-react/.nvmrc
 
       - name: Install
         run: npm ci

--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -33,7 +33,9 @@ jobs:
         with:
           node-version-file: narou-react/.nvmrc
           cache: "npm"
-          cache-dependency-path: "narou-react/package-lock.json"
+          cache-dependency-path: |
+            narou-react/package-lock.json
+            narou-react/.nvmrc
 
       - name: Install
         run: npm ci

--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           node-version-file: narou-react/.nvmrc
           cache: "npm"
-          cache-dependency-path: "narou-react/package-lock.json"
+          cache-dependency-path: |
+            narou-react/package-lock.json
+            narou-react/.nvmrc
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

`.nvmrc` で Node バージョンを一元管理しているが、`.nvmrc` を更新したときに `actions/setup-node` の npm cache key が変わらず、古い Node 用にビルドされた cache を読んでしまう問題を修正。

- **cache key 漏れ**: `actions/setup-node` の組み込み cache key は `cache-dependency-path` のハッシュのみで構成され、`node-version-file` は反映されない。`cache-dependency-path` に `narou-react/package-lock.json` と `narou-react/.nvmrc` を併記することで、Node バージョン更新時に npm cache が確実にミスして再構築される。
- 対象 4 箇所:
  - `.github/workflows/ci.yml` - `react-quality` ジョブ
  - `.github/workflows/ci.yml` - `react-visual` ジョブ
  - `.github/workflows/deploy-client.yml` - `build` ジョブ
  - `.github/workflows/update-visual-snapshots.yml` - `update-snapshots` ジョブ

### 変更不要だった箇所

- `ci.yml` の `npm-audit` ジョブは `cache:` 未指定 (`--package-lock-only` で install しない) のため変更不要
- トリガ側は対応済み:
  - `ci.yml` の `dorny/paths-filter` の `react` フィルタには `narou-react/.nvmrc` が既に含まれている
  - `deploy-client.yml` の push paths は `narou-react/**` で `.nvmrc` を包括している

### 背景

[koizuka/drawing-practice#184](https://github.com/koizuka/drawing-practice/pull/184) の踏襲。

## Test plan

- [x] `go fmt ./...` / `go vet ./...` / `go test ./...` / `go build` パス
- [x] `npm run lint` パス
- [x] `npm run test:ci` パス (77 tests)
- [x] `npm run build` パス
- [ ] (次回 Node バージョン更新 PR で) `.nvmrc` 改変時に setup-node の cache key が前回と異なる (cache miss) ことをログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)