### PR TITLE
feat: ユーザーホームの新着通知バッジを追加

### DIFF
--- a/cmd/model/UserTopNotificationRecord.go
+++ b/cmd/model/UserTopNotificationRecord.go
@@ -1,0 +1,8 @@
+package model
+
+// UserTopNotificationRecord はユーザートップの「新着通知」の有無を表す。
+// 中身はユーザー自身がユーザーホームを開いて確認する想定で、ここでは有無と件数のみ返す。
+type UserTopNotificationRecord struct {
+	HasNotification bool `json:"has_notification"`
+	Count           int  `json:"count"`
+}

--- a/main.go
+++ b/main.go
@@ -160,13 +160,18 @@ func GetIsNoticeList(watcher *narou.NarouWatcher, url string, wantTitle string, 
 	return result, nil
 }
 
-func GetFavUserUpdates(watcher *narou.NarouWatcher, URL string) (*model.FavUserUpdatesRecord, error) {
+// fetchUserTopApiResult はユーザートップ async API (JSONP) を取得してパースする。
+// fav-user-updates と notification の両ハンドラが共有する。
+func fetchUserTopApiResult(watcher *narou.NarouWatcher, URL string) (*narou.UserTopApiResult, error) {
 	j, err := watcher.GetJSONP(URL, "func")
 	if err != nil {
 		return nil, err
 	}
+	return narou.ParseUserTopApiJson(j)
+}
 
-	info, err := narou.ParseUserTopApiJson(j)
+func GetFavUserUpdates(watcher *narou.NarouWatcher, URL string) (*model.FavUserUpdatesRecord, error) {
+	info, err := fetchUserTopApiResult(watcher, URL)
 	if err != nil {
 		return nil, err
 	}
@@ -194,6 +199,24 @@ func GetFavUserUpdates(watcher *narou.NarouWatcher, URL string) (*model.FavUserU
 	}
 
 	return result, nil
+}
+
+// newUserTopNotificationRecord は usertop API 結果の news から通知レコードを組み立てる。
+// 本番(GetUserTopNotification)とテストデータ(testDataNotificationHandler)で共有する。
+func newUserTopNotificationRecord(info *narou.UserTopApiResult) *model.UserTopNotificationRecord {
+	hasNotification, count := narou.ParseUserTopNews(info.NewsHTML)
+	return &model.UserTopNotificationRecord{
+		HasNotification: hasNotification,
+		Count:           count,
+	}
+}
+
+func GetUserTopNotification(watcher *narou.NarouWatcher, URL string) (*model.UserTopNotificationRecord, error) {
+	info, err := fetchUserTopApiResult(watcher, URL)
+	if err != nil {
+		return nil, err
+	}
+	return newUserTopNotificationRecord(info), nil
 }
 
 func parseURLForCookie(url *url.URL) (isHttps bool, cookiePath string) {
@@ -570,30 +593,56 @@ func isNoticeListHandler(url string, wantTitle string) NarouApiHandlerType {
 	}
 }
 
+// resolveUserTopApiURL はユーザートップ async API のトークンを解決し、
+// URL にトークンクエリを付与した文字列を返す。
+// リクエストクエリに token があればそれを使い、無ければユーザートップページを
+// 取得してトークンを抽出し、レスポンスヘッダにも反映する。
+func resolveUserTopApiURL(w http.Header, r *http.Request, watcher *narou.NarouWatcher, URL string) (string, error) {
+	query := r.URL.Query()
+	token, ok := query["token"]
+	if !ok {
+		page, err := watcher.GetPage(narou.UserTopURL)
+		if err != nil {
+			return "", err
+		}
+		info, err := narou.ParseUserTop(page)
+		if err != nil {
+			return "", err
+		}
+		token = []string{info.Logout.Token}
+		w.Set("token", token[0])
+	}
+	u, err := url.Parse(URL)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Add("token", token[0])
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
 func favUserUpdatesHandler(URL string) NarouApiHandlerType {
 	return func(w http.Header, r *http.Request, watcher *narou.NarouWatcher) ([]byte, error) {
-		query := r.URL.Query()
-		token, ok := query["token"]
-		if !ok {
-			page, err := watcher.GetPage(narou.UserTopURL)
-			if err != nil {
-				return nil, err
-			}
-			info, err := narou.ParseUserTop(page)
-			if err != nil {
-				return nil, err
-			}
-			token = []string{info.Logout.Token}
-			w.Set("token", token[0])
-		}
-		u, err := url.Parse(URL)
+		apiURL, err := resolveUserTopApiURL(w, r, watcher, URL)
 		if err != nil {
 			return nil, err
 		}
-		q := u.Query()
-		q.Add("token", token[0])
-		u.RawQuery = q.Encode()
-		result, err := GetFavUserUpdates(watcher, u.String())
+		result, err := GetFavUserUpdates(watcher, apiURL)
+		if err != nil {
+			return nil, err
+		}
+		return ReturnJson(w, result)
+	}
+}
+
+func notificationHandler(URL string) NarouApiHandlerType {
+	return func(w http.Header, r *http.Request, watcher *narou.NarouWatcher) ([]byte, error) {
+		apiURL, err := resolveUserTopApiURL(w, r, watcher, URL)
+		if err != nil {
+			return nil, err
+		}
+		result, err := GetUserTopNotification(watcher, apiURL)
 		if err != nil {
 			return nil, err
 		}
@@ -810,10 +859,12 @@ func main() {
 		setHandler("/narou/isnoticelist", testDataIsNoticeListHandler(testDataProvider))
 		setHandler("/r18/isnoticelist", testDataIsNoticeListHandler(testDataProvider))
 		setHandler("/narou/fav-user-updates", testDataFavUserUpdatesHandler(testDataProvider))
+		setHandler("/narou/notification", testDataNotificationHandler(testDataProvider))
 	} else {
 		setHandler("/narou/isnoticelist", isNoticeListHandler(narou.IsNoticeListURL, narou.IsNoticeListTitle))
 		setHandler("/r18/isnoticelist", isNoticeListHandler(narou.IsNoticeListR18URL, narou.IsNoticeListR18Title))
 		setHandler("/narou/fav-user-updates", favUserUpdatesHandler(narou.UserTopApiURL))
+		setHandler("/narou/notification", notificationHandler(narou.UserTopApiURL))
 	}
 
 	setHandler("/narou/login", NarouLoginHandler)

--- a/main.go
+++ b/main.go
@@ -598,9 +598,8 @@ func isNoticeListHandler(url string, wantTitle string) NarouApiHandlerType {
 // リクエストクエリに token があればそれを使い、無ければユーザートップページを
 // 取得してトークンを抽出し、レスポンスヘッダにも反映する。
 func resolveUserTopApiURL(w http.Header, r *http.Request, watcher *narou.NarouWatcher, URL string) (string, error) {
-	query := r.URL.Query()
-	token, ok := query["token"]
-	if !ok {
+	token := r.URL.Query().Get("token")
+	if token == "" {
 		page, err := watcher.GetPage(narou.UserTopURL)
 		if err != nil {
 			return "", err
@@ -609,15 +608,15 @@ func resolveUserTopApiURL(w http.Header, r *http.Request, watcher *narou.NarouWa
 		if err != nil {
 			return "", err
 		}
-		token = []string{info.Logout.Token}
-		w.Set("token", token[0])
+		token = info.Logout.Token
+		w.Set("token", token)
 	}
 	u, err := url.Parse(URL)
 	if err != nil {
 		return "", err
 	}
 	q := u.Query()
-	q.Add("token", token[0])
+	q.Set("token", token)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }

--- a/narou-react/src/components/NarouUpdates.test.tsx
+++ b/narou-react/src/components/NarouUpdates.test.tsx
@@ -28,6 +28,7 @@ function setup() {
 		} as unknown as NarouApi;
 	})
 	NarouApi.isnoticelist = vi.fn(() => 'isnoticelist');
+	NarouApi.notification = vi.fn(() => '/narou/notification');
 	NarouApi.checkNovelAccess = vi.fn((ncode: string, episode: number, r18: boolean) =>
 		`${r18 ? '/r18' : '/narou'}/check-novel-access/${ncode}/${episode}`
 	);
@@ -97,6 +98,72 @@ test('empty', async () => {
 	// TODO
 });
 
+test('shows notification badge on user home button when has_notification is true', async () => {
+	const { mockCall, api } = setup();
+	mockCall.mockImplementation((key: string) => {
+		if (key === 'isnoticelist') {
+			return Promise.resolve([]);
+		}
+		if (key === '/narou/notification') {
+			return Promise.resolve({ has_notification: true, count: 1 });
+		}
+		return Promise.reject(new Error(`Unexpected API call: ${key}`));
+	});
+
+	let container: HTMLElement = document.createElement('div');
+	await act(async () => {
+		container = render(
+			<ThemeProvider theme={theme}>
+				<SWRConfig value={{ provider: () => new Map() }}>
+					<NarouUpdates api={api} />
+				</SWRConfig>
+			</ThemeProvider>
+		).container;
+		return Promise.resolve();
+	});
+
+	// variant="dot" のバッジは通知ボタン専用なので一意に取得できる
+	await waitFor(() => {
+		const dot = container.querySelector('.MuiBadge-dot');
+		expect(dot).toBeTruthy();
+		expect(dot?.classList.contains('MuiBadge-invisible')).toBe(false);
+	});
+});
+
+test('hides notification badge on user home button when has_notification is false', async () => {
+	const { mockCall, api } = setup();
+	mockCall.mockImplementation((key: string) => {
+		if (key === 'isnoticelist') {
+			return Promise.resolve([]);
+		}
+		if (key === '/narou/notification') {
+			return Promise.resolve({ has_notification: false, count: 0 });
+		}
+		return Promise.reject(new Error(`Unexpected API call: ${key}`));
+	});
+
+	let container: HTMLElement = document.createElement('div');
+	await act(async () => {
+		container = render(
+			<ThemeProvider theme={theme}>
+				<SWRConfig value={{ provider: () => new Map() }}>
+					<NarouUpdates api={api} />
+				</SWRConfig>
+			</ThemeProvider>
+		).container;
+		return Promise.resolve();
+	});
+
+	// notification を取得した後もバッジは invisible のまま
+	await waitFor(() => {
+		const calls = mockCall.mock.calls;
+		expect(calls.some(call => call[0] === '/narou/notification')).toBe(true);
+	});
+	const dot = container.querySelector('.MuiBadge-dot');
+	expect(dot).toBeTruthy();
+	expect(dot?.classList.contains('MuiBadge-invisible')).toBe(true);
+});
+
 test('proactively checks first beware novel accessibility', async () => {
 	const { mockCall, api } = setup();
 
@@ -131,6 +198,9 @@ test('proactively checks first beware novel accessibility', async () => {
 	mockCall.mockImplementation((key: string) => {
 		if (key === 'isnoticelist') {
 			return Promise.resolve(mockItems);
+		}
+		if (key === '/narou/notification') {
+			return Promise.resolve({ has_notification: false, count: 0 });
 		}
 		// Proactive check for the first beware novel
 		if (key === '/narou/check-novel-access/n1111aa/6') {
@@ -179,6 +249,9 @@ test('does not check if no beware novels exist', async () => {
 	mockCall.mockImplementation((key: string) => {
 		if (key === 'isnoticelist') {
 			return Promise.resolve(mockItems);
+		}
+		if (key === '/narou/notification') {
+			return Promise.resolve({ has_notification: false, count: 0 });
 		}
 		return Promise.reject(new Error(`Unexpected API call: ${key}`));
 	});

--- a/narou-react/src/components/NarouUpdates.tsx
+++ b/narou-react/src/components/NarouUpdates.tsx
@@ -1,6 +1,7 @@
 import {
   AppBar,
   Backdrop,
+  Badge,
   Box,
   Button,
   CircularProgress,
@@ -18,6 +19,7 @@ import { useProactiveNovelCheck } from '../hooks/useProactiveNovelCheck';
 import { IsNoticeListItem } from "../narouApi/IsNoticeListItem";
 import { NarouApi } from '../narouApi/NarouApi';
 import { clearCache, useIsNoticeList } from '../narouApi/useIsNoticeList';
+import { useNotification } from '../narouApi/useNotification';
 import { BEWARE_TIME, InitialItemsState, itemsStateReducer, SelectCommand } from '../reducer/ItemsState';
 import { AutoLinkText } from './AutoLinkText';
 import { BookmarkSelector } from './BookmarkSelector';
@@ -75,6 +77,7 @@ function NarouUpdateScreen({ server, onUnauthorized }: { server: NarouApi, onUna
   const { setClientBadge, clearClientBadge } = getClientBadge();
 
   const userTopURL = enableR18 ? R18UserTopURL : UserTopURL;
+  const { hasNotification } = useNotification(server);
 
   useEffect(() => {
     if (numNewItems !== null) {
@@ -188,13 +191,25 @@ function NarouUpdateScreen({ server, onUnauthorized }: { server: NarouApi, onUna
         />
       </Box>
       <Box sx={{ position: 'fixed', right: '20px', bottom: '20px' }}>
-        <Fab
-          variant="extended"
-          size="small"
-          component="a"
-          href={userTopURL}
-          target="_blank"
-        >{enableR18 ? R18UserTopName : UserTopName}</Fab>
+        <Badge
+          color="error"
+          variant="dot"
+          invisible={!hasNotification}
+          sx={{
+            '& .MuiBadge-badge': {
+              transform: 'translate(-25%, 25%)',
+              zIndex: (theme) => theme.zIndex.fab + 1,
+            },
+          }}
+        >
+          <Fab
+            variant="extended"
+            size="small"
+            component="a"
+            href={userTopURL}
+            target="_blank"
+          >{enableR18 ? R18UserTopName : UserTopName}</Fab>
+        </Badge>
       </Box>
     </Box>
   </>;

--- a/narou-react/src/components/NarouUpdates.tsx
+++ b/narou-react/src/components/NarouUpdates.tsx
@@ -208,6 +208,7 @@ function NarouUpdateScreen({ server, onUnauthorized }: { server: NarouApi, onUna
             component="a"
             href={userTopURL}
             target="_blank"
+            rel="noopener noreferrer"
           >{enableR18 ? R18UserTopName : UserTopName}</Fab>
         </Badge>
       </Box>

--- a/narou-react/src/narouApi/NarouApi.ts
+++ b/narou-react/src/narouApi/NarouApi.ts
@@ -85,4 +85,8 @@ export class NarouApi {
         const prefix = r18 ? '/r18' : '/narou';
         return `${prefix}/check-novel-access/${ncode}/${episode}`;
     }
+
+    static notification(): NarouApiCallKey {
+        return `/narou/notification`;
+    }
 }

--- a/narou-react/src/narouApi/useIsNoticeList.tsx
+++ b/narou-react/src/narouApi/useIsNoticeList.tsx
@@ -22,6 +22,7 @@ export function clearCache() {
   void mutate('/r18/isnoticelist');
   void mutate('/narou/bookmarks/');
   void mutate('/r18/bookmarks/');
+  void mutate(NarouApi.notification());
 }
 
 export function useIsNoticeList(

--- a/narou-react/src/narouApi/useNotification.tsx
+++ b/narou-react/src/narouApi/useNotification.tsx
@@ -1,0 +1,20 @@
+import { NarouApi } from './NarouApi';
+import useSWR from 'swr';
+import { ApiError } from './ApiError';
+
+interface UserTopNotification {
+  has_notification: boolean;
+  count: number;
+}
+
+/**
+ * ユーザートップの「新着通知」の有無を取得する。
+ * 通知ソースは通常ホームのみ(R18トグルに関係なく同一)。
+ */
+export function useNotification(api: NarouApi) {
+  const { data, error } = useSWR<UserTopNotification, ApiError>(
+    NarouApi.notification(),
+    async (path: string) => api.call<UserTopNotification>(path));
+
+  return { hasNotification: data?.has_notification ?? false, error };
+}

--- a/narou/TestDataProvider.go
+++ b/narou/TestDataProvider.go
@@ -326,5 +326,6 @@ func (t *TestDataProvider) GetFavUserUpdates() (*UserTopApiResult, error) {
 		R18PassiveCount: 1,
 		BlogListHTML:    "<h3>活動報告</h3><ul><li><a href='#'>テスト活動報告</a> by <a href='#'>テスト作者A</a></li></ul>",
 		NovelListHTML:   fmt.Sprintf("<h3>お気に入りユーザの更新</h3><div id='fanusernovel_list'><div id='fanusernovel_title'><a href='#'>更新したばかりのお気に入りユーザ作品</a></div><div id='fanusernovel_type'><div id='fanusernovel_info'>%s</div><a href='#'>テスト作者A</a></div></div>", t.startTime.Format("01月02日 15時04分")),
+		NewsHTML:        "<div class=\"p-up-home-notification__item\"><a href=\"/ranknovel18log/search/\">R18作品がランクインしました</a></div>",
 	}, nil
 }

--- a/narou/UserTopApi.go
+++ b/narou/UserTopApi.go
@@ -24,7 +24,7 @@ func ParseUserTopApiJson(JSON string) (*UserTopApiResult, error) {
 	var info UserTopApiResult
 	err := json.Unmarshal([]byte(JSON), &info)
 	if err != nil {
-		return nil, fmt.Errorf("ParseFavuserUpdatesJson: json.Unmarshal error %v", err)
+		return nil, fmt.Errorf("ParseUserTopApiJson: json.Unmarshal error %w", err)
 	}
 	return &info, nil
 }

--- a/narou/UserTopApi.go
+++ b/narou/UserTopApi.go
@@ -3,6 +3,9 @@ package narou
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
 )
 
 const (
@@ -14,6 +17,7 @@ type UserTopApiResult struct {
 	BlogListHTML    string `json:"favuserblogList"`
 	NovelListHTML   string `json:"favusernovelList"`
 	PassiveCount    int    `json:"favuserpassivecnt"`
+	NewsHTML        string `json:"news"`
 }
 
 func ParseUserTopApiJson(JSON string) (*UserTopApiResult, error) {
@@ -23,4 +27,21 @@ func ParseUserTopApiJson(JSON string) (*UserTopApiResult, error) {
 		return nil, fmt.Errorf("ParseFavuserUpdatesJson: json.Unmarshal error %v", err)
 	}
 	return &info, nil
+}
+
+// ParseUserTopNews はユーザートップの「新着通知」(news) HTML 断片から
+// 通知の有無と件数を返す。
+// 判定は特定の通知種別(ランクイン等)に依存せず、news が空でなければ通知ありとする。
+// 件数は <div class="p-up-home-notification__item"> の数を数えるが、
+// その要素が見つからない場合でも news が非空なら hasNotification は true を返す。
+func ParseUserTopNews(newsHTML string) (hasNotification bool, count int) {
+	if strings.TrimSpace(newsHTML) == "" {
+		return false, 0
+	}
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(newsHTML))
+	if err == nil {
+		count = doc.Find("div.p-up-home-notification__item").Length()
+	}
+	return true, count
 }

--- a/narou/UserTopApi_test.go
+++ b/narou/UserTopApi_test.go
@@ -1,0 +1,94 @@
+package narou
+
+import "testing"
+
+func TestParseUserTopNews(t *testing.T) {
+	tests := []struct {
+		name      string
+		newsHTML  string
+		wantHas   bool
+		wantCount int
+	}{
+		{
+			name:      "通知あり(実レスポンス)",
+			newsHTML:  "\t<div class=\"p-up-home-notification__item\"><a href=\"/ranknovel18log/search/\">R18作品がランクインしました</a></div>\n",
+			wantHas:   true,
+			wantCount: 1,
+		},
+		{
+			name:      "通知あり(複数件)",
+			newsHTML:  "<div class=\"p-up-home-notification__item\"><a href=\"#\">通知1</a></div><div class=\"p-up-home-notification__item\"><a href=\"#\">通知2</a></div>",
+			wantHas:   true,
+			wantCount: 2,
+		},
+		{
+			name:      "通知なし(空文字列)",
+			newsHTML:  "",
+			wantHas:   false,
+			wantCount: 0,
+		},
+		{
+			name:      "通知なし(空白のみ)",
+			newsHTML:  "\t\n ",
+			wantHas:   false,
+			wantCount: 0,
+		},
+		{
+			name:      "非空だが既知のクラスなし(フォールバックで有り判定)",
+			newsHTML:  "<div class=\"unknown\">なにかの通知</div>",
+			wantHas:   true,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			has, count := ParseUserTopNews(tt.newsHTML)
+			if has != tt.wantHas {
+				t.Errorf("hasNotification = %v, want %v", has, tt.wantHas)
+			}
+			if count != tt.wantCount {
+				t.Errorf("count = %v, want %v", count, tt.wantCount)
+			}
+		})
+	}
+}
+
+// TestParseUserTopApiJsonNoNews は、通知が無いとき usertop async API のレスポンスから
+// "news" キー自体が省略されることを実環境で確認した挙動を固定する。
+// キー欠落・null・空文字列のいずれでも NewsHTML は空となり、通知なしと判定される。
+func TestParseUserTopApiJsonNoNews(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "newsキーが省略されている(実環境で確認)",
+			json: `{"favuserblogList":"<ul></ul>","favusernovelList":"<ul></ul>","cheersprogram":""}`,
+		},
+		{
+			name: "newsがnull",
+			json: `{"news":null,"favusernovelList":"<ul></ul>"}`,
+		},
+		{
+			name: "newsが空文字列",
+			json: `{"news":"","favusernovelList":"<ul></ul>"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := ParseUserTopApiJson(tt.json)
+			if err != nil {
+				t.Fatalf("ParseUserTopApiJson error: %v", err)
+			}
+			has, count := ParseUserTopNews(info.NewsHTML)
+			if has {
+				t.Errorf("hasNotification = true, want false (NewsHTML=%q)", info.NewsHTML)
+			}
+			if count != 0 {
+				t.Errorf("count = %v, want 0", count)
+			}
+		})
+	}
+}

--- a/testdata_handlers.go
+++ b/testdata_handlers.go
@@ -152,3 +152,15 @@ func testDataFavUserUpdatesHandler(provider *narou.TestDataProvider) NarouApiHan
 		return ReturnJson(w, result)
 	}
 }
+
+// testDataNotificationHandler returns test data for the user top notification endpoint
+func testDataNotificationHandler(provider *narou.TestDataProvider) NarouApiHandlerType {
+	return func(w http.Header, r *http.Request, watcher *narou.NarouWatcher) ([]byte, error) {
+		info, err := provider.GetFavUserUpdates()
+		if err != nil {
+			return nil, err
+		}
+
+		return ReturnJson(w, newUserTopNotificationRecord(info))
+	}
+}


### PR DESCRIPTION
## 概要

「小説家になろう」ユーザートップの「新着通知」(`news`)欄の有無を API で返し、フロントの「ユーザーホーム」ボタンにドットバッジを表示します。

この通知欄はページHTMLには静的に存在せず、JS が `api.syosetu.com/async/usertop/`(JSONP)から動的に読み込んでいます。バックエンドは既に同じ usertop async API を fav-user-updates で叩いているため、その仕組みを流用しました。

中身はユーザー自身がユーザーホームを開いて確認する想定で、API は**有無(と件数)のみ**を返します。

## 変更内容

### バックエンド
- `UserTopApiResult` に `news` フィールドを追加、`ParseUserTopNews` で通知有無/件数を判定
  - 特定の通知種別に依存せず、`news` が空でなければ通知ありと判定
  - `p-up-home-notification__item` の件数をカウント、未知構造でも `TrimSpace` フォールバックで拾う
- `/narou/notification` エンドポイント(`GetUserTopNotification` / `notificationHandler`)を追加
- token 解決(`resolveUserTopApiURL`)・JSONP取得(`fetchUserTopApiResult`)・レコード生成(`newUserTopNotificationRecord`)を `favUserUpdatesHandler` と共通化
- testdata モード対応(`testDataNotificationHandler`)

### フロントエンド
- `useNotification` hook と `NarouApi.notification()` を追加
- ユーザーホーム `Fab` を MUI `Badge`(`variant="dot"`)でラップし、通知ありのときボタン右上にドット表示
- `clearCache` に `/narou/notification` を追加(ログイン/ログアウト時のキャッシュ取り残しを防止)

## 設計メモ
- 通知ソースは**通常ホームのみ**を監視します。
- 通知なし時は async API レスポンスから `news` キー自体が消えることを実環境で確認し、回帰テストで固定。

## テスト
- Go: `ParseUserTopNews`(通知あり/なし/フォールバック)、`news` キー欠落・null・空文字列の挙動 → pass
- React: バッジの表示/非表示 → pass(全79件)
- `go build` / `go vet` / `go test` / `npm run lint` / `npm run test:ci` / `npm run build` すべて成功
- testdata モード + ブラウザで、ボタン右上にドットバッジが重なって前面表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)