### PR TITLE
feat: 全APIエンドポイントに no-cache ヘッダを横断適用

### DIFF
--- a/main.go
+++ b/main.go
@@ -276,6 +276,10 @@ func (e BadRequestError) Error() string {
 
 func (apiService *NarouApiService) HandlerFunc(handler NarouApiHandlerType) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// API レスポンスは動的データなので、ブラウザ・中間キャッシュに保持させない。
+		// 全 API エンドポイント共通の経路でまとめて設定する。
+		SetNoCacheHeaders(w.Header())
+
 		watcher, err := narou.NewNarouWatcher(narou.Options{
 			SessionName: apiService.sessionName,
 			FilePrefix:  apiService.logDir + "/",
@@ -697,7 +701,6 @@ func checkNovelAccessHandler(baseUrl string, r18 bool) NarouApiHandlerType {
 			StatusCode: resp.StatusCode,
 		}
 
-		SetNoCacheHeaders(w)
 		return ReturnJson(w, result)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"narou-watcher/narou"
+)
+
+// TestHandlerFuncSetsNoCacheHeaders は、全 API エンドポイント共通の HandlerFunc 経路で
+// no-cache ヘッダが付与されることを検証する(成功・エラーいずれの応答でも)。
+func TestHandlerFuncSetsNoCacheHeaders(t *testing.T) {
+	openAddress, _ := url.Parse("http://localhost:7676")
+	svc := NewNarouApiService(t.TempDir(), "test-session", openAddress, false)
+
+	tests := []struct {
+		name    string
+		handler NarouApiHandlerType
+	}{
+		{
+			name: "success",
+			handler: func(w http.Header, r *http.Request, watcher *narou.NarouWatcher) ([]byte, error) {
+				return ReturnJson(w, map[string]bool{"ok": true})
+			},
+		},
+		{
+			name: "error",
+			handler: func(w http.Header, r *http.Request, watcher *narou.NarouWatcher) ([]byte, error) {
+				return nil, errors.New("boom")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/narou/notification", nil)
+			rec := httptest.NewRecorder()
+			svc.HandlerFunc(tt.handler)(rec, req)
+
+			res := rec.Result()
+			if got := res.Header.Get("Cache-Control"); !strings.Contains(got, "no-store") {
+				t.Errorf("Cache-Control = %q, want to contain no-store", got)
+			}
+			if got := res.Header.Get("Pragma"); got != "no-cache" {
+				t.Errorf("Pragma = %q, want no-cache", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2187

## 概要

動的データを返す JSON API エンドポイントの多くが `Cache-Control` / `Pragma` などの no-cache ヘッダを設定しておらず、ブラウザや中間キャッシュがレスポンスを再利用すると古い状態が表示されうる問題への対応です。

これまで `SetNoCacheHeaders` は `check-novel-access` ハンドラでのみ明示的に呼ばれており、`/narou/isnoticelist` や `/narou/fav-user-updates`、`/narou/notification` などは no-cache が付いていませんでした。

## 変更内容

- 全 API エンドポイント共通の経路である `HandlerFunc` ラッパーで `SetNoCacheHeaders(w.Header())` を一括設定
  - これにより isnoticelist / bookmarks / novels / fav-user-updates / notification / login / logout などすべてが no-cache になる
  - 成功・エラーいずれの応答でもヘッダが付く(ハンドラ実行前に設定)
- `checkNovelAccessHandler` の個別 `SetNoCacheHeaders` 呼び出しは冗長になるため削除
- `main_test.go` を追加し、成功・エラー両応答で no-cache ヘッダが付与されることを httptest で検証

## テスト
- `go vet ./...` / `go test ./...` すべて成功(新規 `TestHandlerFuncSetsNoCacheHeaders` 含む)
- testdata モードで `/narou/notification`・`/narou/isnoticelist` の双方に `Cache-Control: no-store, no-cache, must-revalidate, max-age=0` / `Pragma: no-cache` が付与されることを確認

## 補足
リバースプロキシ経由のフロント静的アセット(`mux.HandleFunc("/", ...)`)は `HandlerFunc` を通らないため影響を受けません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)