### PR TITLE
fix: ユーザートップのタイトル変更に追従しトークン取得の500を解消

### DIFF
--- a/narou/UserTop.go
+++ b/narou/UserTop.go
@@ -18,7 +18,7 @@ type UserTopInfo struct {
 }
 
 func ParseUserTop(page *scraper.Page) (*UserTopInfo, error) {
-	const wantTitle = "ホーム｜ユーザページ"
+	const wantTitle = "ユーザホーム | ユーザページ | 小説家になろう"
 	title := page.Find("title").Text()
 	if title != wantTitle {
 		return nil, TitleMismatchError{title, wantTitle}

--- a/narou/UserTopApi_test.go
+++ b/narou/UserTopApi_test.go
@@ -1,6 +1,45 @@
 package narou
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseUserTop は、ユーザートップページのタイトル検証とトークン抽出を固定する。
+// なろうがページタイトルを変更すると token 取得経路(notification / fav-user-updates)が
+// 500 になるため、現行タイトルを回帰テストとして固定しておく。
+func TestParseUserTop(t *testing.T) {
+	const wantTitle = "ユーザホーム | ユーザページ | 小説家になろう"
+
+	t.Run("正常: 現行タイトルでトークンを抽出", func(t *testing.T) {
+		html := `<html><head><title>` + wantTitle + `</title></head>` +
+			`<body><div id="header"><a id="logout" href="/logout/?token=abc123" data-token="abc123">ログアウト</a></div></body></html>`
+		page, err := NewPageFromText(html)
+		if err != nil {
+			t.Fatalf("NewPageFromText error: %v", err)
+		}
+		info, err := ParseUserTop(page)
+		if err != nil {
+			t.Fatalf("ParseUserTop error: %v", err)
+		}
+		if info.Logout.Token != "abc123" {
+			t.Errorf("Token = %q, want %q", info.Logout.Token, "abc123")
+		}
+	})
+
+	t.Run("タイトル不一致はエラー", func(t *testing.T) {
+		html := `<html><head><title>ホーム｜ユーザページ</title></head><body></body></html>`
+		page, err := NewPageFromText(html)
+		if err != nil {
+			t.Fatalf("NewPageFromText error: %v", err)
+		}
+		_, err = ParseUserTop(page)
+		wantErr := TitleMismatchError{"ホーム｜ユーザページ", wantTitle}
+		if !reflect.DeepEqual(err, wantErr) {
+			t.Errorf("error = %v, want %v", err, wantErr)
+		}
+	})
+}
 
 func TestParseUserTopNews(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## 概要

なろうがユーザートップページの `<title>` を変更したため、`ParseUserTop` のタイトル検証で弾かれ、トークン取得が **500** になっていた。新着通知バッジが表示されない不具合の根本原因。

| | タイトル |
|---|---|
| 旧（コードの期待値） | `ホーム｜ユーザページ` |
| 現行（なろう） | `ユーザホーム \| ユーザページ \| 小説家になろう` |

## なぜ見逃されていたか

このトークン取得経路は `/narou/notification` と `/narou/fav-user-updates` の両エンドポイントが利用する。後者はフロント未使用だったため、なろうがタイトルを変更しても誰も気づかなかった。新着通知バッジ機能が初めてこの経路を本番で叩いて顕在化した。

他のタイトル定数（`FavNovelList.go`）は既に新形式（`〜 | ユーザページ | 小説家になろう`）へ更新済みで、`ParseUserTop` だけ旧形式が取り残されていた。

## 変更内容

- `narou/UserTop.go`: 期待タイトルを現行の形式へ更新
- `narou/UserTopApi_test.go`: `ParseUserTop` のタイトル検証・トークン抽出を固定する回帰テストを追加（正常系 / タイトル不一致系）

## 検証

- `go test ./...` 全緑
- 公開エンドポイント `…/notification`（要ログイン）で 500 → 正常レスポンスに復帰することを確認予定

## 影響範囲

- フロント側の変更は不要。グローバル `SWRConfig` の `refreshInterval` により、デプロイ後5分以内（またはタブ復帰時）に自動でバッジが反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)