### PR TITLE
fix: ユーザートップのトークン/ログアウトを新デザイン構造に追従

### DIFF
--- a/main.go
+++ b/main.go
@@ -612,7 +612,7 @@ func resolveUserTopApiURL(w http.Header, r *http.Request, watcher *narou.NarouWa
 		if err != nil {
 			return "", err
 		}
-		token = info.Logout.Token
+		token = info.Token
 		w.Set("token", token)
 	}
 	u, err := url.Parse(URL)

--- a/narou/NarouWatcher.go
+++ b/narou/NarouWatcher.go
@@ -168,12 +168,8 @@ func (narou *NarouWatcher) Logout() error {
 	if err != nil {
 		return err
 	}
-	form := &scraper.Form{
-		Action: info.Logout.URL,
-		Method: "post",
-	}
-	_ = form.Set("token", info.Logout.Token)
-	_, err = narou.session.Submit(form)
+	// 現行デザインのログアウトはトークン無しの GET リンク。
+	_, err = narou.session.GetPage(info.LogoutURL)
 	if err != nil {
 		return err
 	}

--- a/narou/UserTop.go
+++ b/narou/UserTop.go
@@ -1,6 +1,9 @@
 package narou
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/koizuka/scraper"
 )
 
@@ -8,14 +11,22 @@ const (
 	UserTopURL = "https://syosetu.com/user/top/"
 )
 
-type LogoutInfo struct {
-	URL   string `attr:"href"`
-	Token string `attr:"data-token"`
+type UserTopInfo struct {
+	// Token はユーザートップのインラインスクリプトに埋め込まれた
+	// async API 用トークン。
+	Token string
+	// LogoutURL はログアウトリンクの URL。
+	LogoutURL string
 }
 
-type UserTopInfo struct {
-	Logout LogoutInfo `find:"div#header a#logout"`
-}
+// usertopTokenRe はユーザートップページのインラインスクリプトに埋め込まれた
+// async API URL からトークンを抽出する。
+//
+//	var usertop_url = "https://api.syosetu.com/async/usertop/?token=XXXX";
+//
+// 旧デザインでは a#logout の data-token 属性にトークンがあったが、
+// 現行デザインではこのスクリプト変数に移動している。
+var usertopTokenRe = regexp.MustCompile(`usertop_url\s*=\s*"[^"]*[?&]token=([^"&]+)`)
 
 func ParseUserTop(page *scraper.Page) (*UserTopInfo, error) {
 	const wantTitle = "ユーザホーム | ユーザページ | 小説家になろう"
@@ -24,11 +35,15 @@ func ParseUserTop(page *scraper.Page) (*UserTopInfo, error) {
 		return nil, TitleMismatchError{title, wantTitle}
 	}
 
-	var userTopInfo UserTopInfo
-	err := scraper.Unmarshal(&userTopInfo, page.Find("body"), scraper.UnmarshalOption{})
-	if err != nil {
-		return nil, UnmarshalError{err}
+	m := usertopTokenRe.FindStringSubmatch(page.Find("script").Text())
+	if len(m) < 2 {
+		return nil, fmt.Errorf("ParseUserTop: token not found in usertop_url script")
 	}
 
-	return &userTopInfo, nil
+	logoutURL, ok := page.Find("a[href*='/login/logout/']").Attr("href")
+	if !ok {
+		return nil, fmt.Errorf("ParseUserTop: logout link not found")
+	}
+
+	return &UserTopInfo{Token: m[1], LogoutURL: logoutURL}, nil
 }

--- a/narou/UserTopApi_test.go
+++ b/narou/UserTopApi_test.go
@@ -5,15 +5,23 @@ import (
 	"testing"
 )
 
-// TestParseUserTop は、ユーザートップページのタイトル検証とトークン抽出を固定する。
-// なろうがページタイトルを変更すると token 取得経路(notification / fav-user-updates)が
-// 500 になるため、現行タイトルを回帰テストとして固定しておく。
+// TestParseUserTop は、ユーザートップページのタイトル検証・トークン抽出・
+// ログアウトURL抽出を固定する。
+// なろうがページタイトルや構造を変更すると token 取得経路
+// (notification / fav-user-updates) やログアウトが壊れるため、現行構造を
+// 回帰テストとして固定しておく。トークンは旧デザインの a#logout[data-token] から
+// インラインスクリプトの var usertop_url = "...?token=XXX" へ移動した。
 func TestParseUserTop(t *testing.T) {
 	const wantTitle = "ユーザホーム | ユーザページ | 小説家になろう"
 
-	t.Run("正常: 現行タイトルでトークンを抽出", func(t *testing.T) {
+	t.Run("正常: スクリプトからトークン、リンクからログアウトURLを抽出", func(t *testing.T) {
 		html := `<html><head><title>` + wantTitle + `</title></head>` +
-			`<body><div id="header"><a id="logout" href="/logout/?token=abc123" data-token="abc123">ログアウト</a></div></body></html>`
+			`<body>` +
+			`<li><a href="https://syosetu.com/login/logout/"><span class="p-icon p-icon--logout"></span>ログアウト</a></li>` +
+			`<script>` + "\n" +
+			`var usertop_url = "https://api.syosetu.com/async/usertop/?token=abc123";` + "\n" +
+			`</script>` +
+			`</body></html>`
 		page, err := NewPageFromText(html)
 		if err != nil {
 			t.Fatalf("NewPageFromText error: %v", err)
@@ -22,8 +30,11 @@ func TestParseUserTop(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ParseUserTop error: %v", err)
 		}
-		if info.Logout.Token != "abc123" {
-			t.Errorf("Token = %q, want %q", info.Logout.Token, "abc123")
+		if info.Token != "abc123" {
+			t.Errorf("Token = %q, want %q", info.Token, "abc123")
+		}
+		if info.LogoutURL != "https://syosetu.com/login/logout/" {
+			t.Errorf("LogoutURL = %q, want %q", info.LogoutURL, "https://syosetu.com/login/logout/")
 		}
 	})
 
@@ -37,6 +48,18 @@ func TestParseUserTop(t *testing.T) {
 		wantErr := TitleMismatchError{"ホーム｜ユーザページ", wantTitle}
 		if !reflect.DeepEqual(err, wantErr) {
 			t.Errorf("error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("トークンが無ければエラー", func(t *testing.T) {
+		html := `<html><head><title>` + wantTitle + `</title></head>` +
+			`<body><a href="https://syosetu.com/login/logout/">ログアウト</a></body></html>`
+		page, err := NewPageFromText(html)
+		if err != nil {
+			t.Fatalf("NewPageFromText error: %v", err)
+		}
+		if _, err := ParseUserTop(page); err == nil {
+			t.Error("expected error when token is missing, got nil")
 		}
 	})
 }


### PR DESCRIPTION
## 概要

#2192（タイトル修正）後に判明した**第二の劣化**。なろうの新デザインでユーザートップページの構造が変わり、トークンとログアウトの取得元がいずれも移動していた。タイトルを通過した後、`scraper.Unmarshal` の `div#header a#logout` が0件マッチとなり `unmarshal error: Logout: length(0) != 1` で500になっていた。

## 変更点

### トークン取得
旧: `a#logout` の `data-token` 属性
現行: インラインスクリプトのJS変数
```html
<script>
var usertop_url = "https://api.syosetu.com/async/usertop/?token=XXXX";
</script>
```
→ `ParseUserTop` を正規表現でこのスクリプトからトークン抽出する方式に変更。

### ログアウト
旧: `POST`（action = `a#logout` の href、`token` = data-token）
現行: トークン無しの**GETリンク** `<a href="https://syosetu.com/login/logout/">`
→ `Logout()` をリンク抽出＋GET方式に変更。

### コード
- `narou/UserTop.go`: `UserTopInfo` を `{Token, LogoutURL}` に変更。タイトル検証＋スクリプトからのトークン抽出＋ログアウトリンク抽出に書き換え
- `narou/NarouWatcher.go`: `Logout()` をGET方式へ
- `main.go`: `resolveUserTopApiURL` を `info.Token` 参照へ
- `narou/UserTopApi_test.go`: 回帰テストを新構造へ更新（トークン欠落エラー系も追加）

## 検証

- `go build ./... && go vet ./... && go test ./...` 全緑、gofmt clean
- **実際の保存HTMLでトークン（`91b20315…`）とログアウトURL（`https://syosetu.com/login/logout/`）が正しく抽出されることを確認**

## 要確認（マージ後）

- **新着通知バッジ**: ログイン中に表示されること（本来の目的）
- **ログアウト**: POST→GET へ方式変更したため、実機でログアウトが機能することを確認してほしい（現行ページがGETリンクのため、それに追従）

> 補足: この経路（`ParseUserTop`）は新着通知の追加で初めて本番で叩かれて顕在化したが、同じく `ParseUserTop` を呼ぶログアウトも現状（#2192時点）では同じエラーで壊れていたはず。本PRで両方を修正している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)