### PR TITLE
fix(narou-react): 起動時のリクエスト負荷を削減(2重取得の解消と通知取得の遅延)

### DIFF
--- a/narou-react/src/components/NarouUpdates.tsx
+++ b/narou-react/src/components/NarouUpdates.tsx
@@ -77,7 +77,8 @@ function NarouUpdateScreen({ server, onUnauthorized }: { server: NarouApi, onUna
   const { setClientBadge, clearClientBadge } = getClientBadge();
 
   const userTopURL = enableR18 ? R18UserTopURL : UserTopURL;
-  const { hasNotification } = useNotification(server);
+  // 一覧の取得が終わるまで通知の取得を始めない(起動時の同時接続数を抑える)
+  const { hasNotification } = useNotification(server, rawItems !== undefined);
 
   useEffect(() => {
     if (numNewItems !== null) {

--- a/narou-react/src/hooks/useSessionRestoreRevalidation.test.ts
+++ b/narou-react/src/hooks/useSessionRestoreRevalidation.test.ts
@@ -1,0 +1,49 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { mutate } from 'swr';
+import { useSessionRestoreRevalidation } from './useSessionRestoreRevalidation';
+
+vi.mock('swr', () => ({
+  mutate: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function firePageShow(persisted: boolean) {
+  window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted }));
+}
+
+test('does not revalidate on normal page load (persisted=false)', () => {
+  const { unmount } = renderHook(() => {
+    useSessionRestoreRevalidation();
+  });
+
+  firePageShow(false);
+
+  expect(mutate).not.toHaveBeenCalled();
+  unmount();
+});
+
+test('revalidates on BFCache/session restore (persisted=true)', () => {
+  const { unmount } = renderHook(() => {
+    useSessionRestoreRevalidation();
+  });
+
+  firePageShow(true);
+
+  expect(mutate).toHaveBeenCalledWith(expect.any(Function), undefined, { revalidate: true });
+  unmount();
+});
+
+test('removes listener on unmount', () => {
+  const { unmount } = renderHook(() => {
+    useSessionRestoreRevalidation();
+  });
+  unmount();
+
+  firePageShow(true);
+
+  expect(mutate).not.toHaveBeenCalled();
+});

--- a/narou-react/src/hooks/useSessionRestoreRevalidation.ts
+++ b/narou-react/src/hooks/useSessionRestoreRevalidation.ts
@@ -5,10 +5,16 @@ import { mutate } from 'swr';
  * Firefoxのセッション復元を検出してSWRを再検証する
  *
  * pageshowイベントで再検証をトリガーする。
+ * pageshow は通常のページロードでも毎回発火するため、
+ * persisted (BFCache/セッション復元からの復帰) のときだけ再検証する。
+ * そうしないと初回ロードで全 API が2重リクエストされてしまう。
  */
 export function useSessionRestoreRevalidation() {
   useEffect(() => {
-    const handlePageShow = () => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (!event.persisted) {
+        return;
+      }
       void mutate(() => true, undefined, { revalidate: true });
     };
 

--- a/narou-react/src/narouApi/useNotification.tsx
+++ b/narou-react/src/narouApi/useNotification.tsx
@@ -10,10 +10,13 @@ interface UserTopNotification {
 /**
  * ユーザートップの「新着通知」の有無を取得する。
  * 通知ソースは通常ホームのみ(R18トグルに関係なく同一)。
+ *
+ * サーバ側でユーザートップページ取得+JSONP の2往復が走る重い API のため、
+ * enabled が true になるまで取得を開始しない(一覧表示を優先する)。
  */
-export function useNotification(api: NarouApi) {
+export function useNotification(api: NarouApi, enabled: boolean) {
   const { data, error } = useSWR<UserTopNotification, ApiError>(
-    NarouApi.notification(),
+    enabled ? NarouApi.notification() : null,
     async (path: string) => api.call<UserTopNotification>(path));
 
   return { hasNotification: data?.has_notification ?? false, error };


### PR DESCRIPTION
## 概要

#2185 以降「開いたときにページが出るまで少し時間がかかる」体感があり、本番環境(https://www.koizuka.jp/narou/)で Resource Timing による実測を行ったところ、以下が判明しました。

- `/narou/notification` は約 **590〜1254ms** かかる(サーバ側でユーザートップページ取得+JSONP の2往復)。`isnoticelist`(122〜292ms)・`bookmarks`(142〜348ms)と比べ圧倒的に重い
- `useSessionRestoreRevalidation` の `pageshow` リスナーが**通常のページロードでも毎回発火**し、全 API がロードごとに**2回ずつ**リクエストされていた(キャッシュを undefined にしてから再検証するため、一覧表示も2巡目の取得完了まで遅延)
- 本番サーバは HTTP/1.1 のため同一オリジン同時6接続制限があり、起動時に API だけで6本(3種×2重)が同時に飛び、うち2本を重い notification が約1秒占有していた

## 変更内容

### `useSessionRestoreRevalidation.ts`
- `event.persisted`(BFCache/セッション復元からの復帰)のときだけ SWR を再検証するように修正
- これで初回ロードの2重リクエストが解消され、一覧表示は1巡目の取得(実測 約160ms)で確定
- テストを新規追加(persisted true/false・リスナー解除の3ケース)

### `useNotification` / `NarouUpdates`
- `useNotification` に `enabled` 引数を追加し、一覧(`rawItems`)のロード完了まで SWR キーを `null` にして取得を開始しないよう変更
- 起動時の同時接続の占有がなくなり、バッジは一覧表示直後に表示される

## テスト

- `./check.sh`(go fmt/vet/test/build + npm lint/test:ci/build)すべて成功
- フロントテスト 98件パス(新規3件含む)

## 補足

- Firefox のブラウザ再起動によるセッション復元は新規ロードになるため SWR が最初から取得し直し、再検証は不要という整理です(BFCache 経由の復帰は `persisted=true` で従来どおり再検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)